### PR TITLE
Update Go module path to make it consumable as Go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module openreports.io
+module github.com/openreports/reports-api
 
 go 1.24.0
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -33,6 +33,6 @@ kube::codegen::gen_helpers \
 kube::codegen::gen_client \
     --with-watch \
     --output-dir "${SCRIPT_ROOT}/pkg/client" \
-    --output-pkg "openreports.io/pkg/client" \
+    --output-pkg "github.com/openreports/reports-api/pkg/client" \
     --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
     "${SCRIPT_ROOT}/apis"

--- a/pkg/client/applyconfiguration/openreports.io/v1alpha1/limits.go
+++ b/pkg/client/applyconfiguration/openreports.io/v1alpha1/limits.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	openreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
+	openreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 )
 
 // LimitsApplyConfiguration represents a declarative configuration of the Limits type for use

--- a/pkg/client/applyconfiguration/openreports.io/v1alpha1/reportresult.go
+++ b/pkg/client/applyconfiguration/openreports.io/v1alpha1/reportresult.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	openreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	openreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 )
 
 // ReportResultApplyConfiguration represents a declarative configuration of the ReportResult type for use

--- a/pkg/client/applyconfiguration/utils.go
+++ b/pkg/client/applyconfiguration/utils.go
@@ -18,12 +18,12 @@ limitations under the License.
 package applyconfiguration
 
 import (
+	v1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	internal "github.com/openreports/reports-api/pkg/client/applyconfiguration/internal"
+	openreportsiov1alpha1 "github.com/openreports/reports-api/pkg/client/applyconfiguration/openreports.io/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	internal "openreports.io/pkg/client/applyconfiguration/internal"
-	openreportsiov1alpha1 "openreports.io/pkg/client/applyconfiguration/openreports.io/v1alpha1"
 )
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -21,10 +21,10 @@ import (
 	fmt "fmt"
 	http "net/http"
 
+	openreportsv1alpha1 "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-	openreportsv1alpha1 "openreports.io/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -18,15 +18,15 @@ limitations under the License.
 package fake
 
 import (
+	clientset "github.com/openreports/reports-api/pkg/client/clientset/versioned"
+	openreportsv1alpha1 "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
+	fakeopenreportsv1alpha1 "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-	clientset "openreports.io/pkg/client/clientset/versioned"
-	openreportsv1alpha1 "openreports.io/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	fakeopenreportsv1alpha1 "openreports.io/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -18,12 +18,12 @@ limitations under the License.
 package fake
 
 import (
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -18,12 +18,12 @@ limitations under the License.
 package scheme
 
 import (
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/clusterreport.go
+++ b/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/clusterreport.go
@@ -20,12 +20,12 @@ package v1alpha1
 import (
 	context "context"
 
+	openreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	scheme "github.com/openreports/reports-api/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
-	openreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	scheme "openreports.io/pkg/client/clientset/versioned/scheme"
 )
 
 // ClusterReportsGetter has a method to return a ClusterReportInterface.

--- a/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake/fake_clusterreport.go
+++ b/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake/fake_clusterreport.go
@@ -18,9 +18,9 @@ limitations under the License.
 package fake
 
 import (
+	v1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	openreportsiov1alpha1 "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
-	v1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	openreportsiov1alpha1 "openreports.io/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 )
 
 // fakeClusterReports implements ClusterReportInterface

--- a/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake/fake_openreports.io_client.go
+++ b/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake/fake_openreports.io_client.go
@@ -18,9 +18,9 @@ limitations under the License.
 package fake
 
 import (
+	v1alpha1 "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "openreports.io/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 )
 
 type FakeOpenreportsV1alpha1 struct {

--- a/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake/fake_report.go
+++ b/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/fake/fake_report.go
@@ -18,9 +18,9 @@ limitations under the License.
 package fake
 
 import (
+	v1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	openreportsiov1alpha1 "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
-	v1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	openreportsiov1alpha1 "openreports.io/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 )
 
 // fakeReports implements ReportInterface

--- a/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/openreports.io_client.go
+++ b/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/openreports.io_client.go
@@ -20,9 +20,9 @@ package v1alpha1
 import (
 	http "net/http"
 
+	openreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	scheme "github.com/openreports/reports-api/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
-	openreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	scheme "openreports.io/pkg/client/clientset/versioned/scheme"
 )
 
 type OpenreportsV1alpha1Interface interface {

--- a/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/report.go
+++ b/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1/report.go
@@ -20,12 +20,12 @@ package v1alpha1
 import (
 	context "context"
 
+	openreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	scheme "github.com/openreports/reports-api/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
-	openreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	scheme "openreports.io/pkg/client/clientset/versioned/scheme"
 )
 
 // ReportsGetter has a method to return a ReportInterface.

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -22,13 +22,13 @@ import (
 	sync "sync"
 	time "time"
 
+	versioned "github.com/openreports/reports-api/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/openreports/reports-api/pkg/client/informers/externalversions/internalinterfaces"
+	openreportsio "github.com/openreports/reports-api/pkg/client/informers/externalversions/openreports.io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-	versioned "openreports.io/pkg/client/clientset/versioned"
-	internalinterfaces "openreports.io/pkg/client/informers/externalversions/internalinterfaces"
-	openreportsio "openreports.io/pkg/client/informers/externalversions/openreports.io"
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -20,9 +20,9 @@ package externalversions
 import (
 	fmt "fmt"
 
+	v1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-	v1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 )
 
 // GenericInformer is type of SharedIndexInformer which will locate and delegate to other

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -20,10 +20,10 @@ package internalinterfaces
 import (
 	time "time"
 
+	versioned "github.com/openreports/reports-api/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
-	versioned "openreports.io/pkg/client/clientset/versioned"
 )
 
 // NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.

--- a/pkg/client/informers/externalversions/openreports.io/interface.go
+++ b/pkg/client/informers/externalversions/openreports.io/interface.go
@@ -18,8 +18,8 @@ limitations under the License.
 package openreports
 
 import (
-	internalinterfaces "openreports.io/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "openreports.io/pkg/client/informers/externalversions/openreports.io/v1alpha1"
+	internalinterfaces "github.com/openreports/reports-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/openreports/reports-api/pkg/client/informers/externalversions/openreports.io/v1alpha1"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/openreports.io/v1alpha1/clusterreport.go
+++ b/pkg/client/informers/externalversions/openreports.io/v1alpha1/clusterreport.go
@@ -21,14 +21,14 @@ import (
 	context "context"
 	time "time"
 
+	apisopenreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	versioned "github.com/openreports/reports-api/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/openreports/reports-api/pkg/client/informers/externalversions/internalinterfaces"
+	openreportsiov1alpha1 "github.com/openreports/reports-api/pkg/client/listers/openreports.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisopenreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	versioned "openreports.io/pkg/client/clientset/versioned"
-	internalinterfaces "openreports.io/pkg/client/informers/externalversions/internalinterfaces"
-	openreportsiov1alpha1 "openreports.io/pkg/client/listers/openreports.io/v1alpha1"
 )
 
 // ClusterReportInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/openreports.io/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/openreports.io/v1alpha1/interface.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "openreports.io/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/openreports/reports-api/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/openreports.io/v1alpha1/report.go
+++ b/pkg/client/informers/externalversions/openreports.io/v1alpha1/report.go
@@ -21,14 +21,14 @@ import (
 	context "context"
 	time "time"
 
+	apisopenreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	versioned "github.com/openreports/reports-api/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/openreports/reports-api/pkg/client/informers/externalversions/internalinterfaces"
+	openreportsiov1alpha1 "github.com/openreports/reports-api/pkg/client/listers/openreports.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisopenreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
-	versioned "openreports.io/pkg/client/clientset/versioned"
-	internalinterfaces "openreports.io/pkg/client/informers/externalversions/internalinterfaces"
-	openreportsiov1alpha1 "openreports.io/pkg/client/listers/openreports.io/v1alpha1"
 )
 
 // ReportInformer provides access to a shared informer and lister for

--- a/pkg/client/listers/openreports.io/v1alpha1/clusterreport.go
+++ b/pkg/client/listers/openreports.io/v1alpha1/clusterreport.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	openreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"
-	openreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 )
 
 // ClusterReportLister helps list ClusterReports.

--- a/pkg/client/listers/openreports.io/v1alpha1/report.go
+++ b/pkg/client/listers/openreports.io/v1alpha1/report.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	openreportsiov1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"
-	openreportsiov1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 )
 
 // ReportLister helps list Reports.


### PR DESCRIPTION
I am currently unable to consume this module as a Go dependency:

````
$ go get openreports.io
go: unrecognized import path "openreports.io": parse https://openreports.io/?go-get=1: no go-import meta tags ()
$ go get github.com/openreports/reports-api
go: github.com/openreports/reports-api@upgrade (v0.0.0-20250717145034-41a243295b93) requires github.com/openreports/reports-api@v0.0.0-20250717145034-41a243295b93: parsing go.mod:
        module declares its path as: openreports.io
                but was required as: github.com/openreports/reports-api
````

It seems like something is missing to use the openreports.io vanity domain.