### PR TITLE
ci: Add release workflow

### DIFF
--- a/.github/actions/setup-build-env/action.yaml
+++ b/.github/actions/setup-build-env/action.yaml
@@ -1,0 +1,33 @@
+name: Setup build env
+
+inputs:
+  unshallow:
+    description: "git unshallow"
+    default: 'true'
+  free-disk-space:
+    description: "free disk space"
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: jlumbroso/free-disk-space@v1.3.1         # pin to the latest v1.3.1 release
+      if: ${{ inputs.free-disk-space == 'true' }}
+      with:
+        android: true
+        docker-images: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: true
+    - shell: bash
+      if: ${{ inputs.unshallow == 'true' }}
+      run: |
+        git fetch --prune --unshallow
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        go-version-file: go.mod
+    - shell: bash
+      run: |
+        go mod download

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - /
+    schedule:
+      interval: daily
+    rebase-strategy: disabled
+    groups:
+      kubernetes:
+        patterns:
+          - k8s.io/*
+  - package-ecosystem: github-actions
+    directories:
+      - /
+      - /.github/actions/*/
+    schedule:
+      interval: daily
+    rebase-strategy: disabled
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: daily
+    rebase-strategy: disabled

--- a/.github/workflows/check-actions.yaml
+++ b/.github/workflows/check-actions.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Check actions
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5 # v3.0.25
+        with:
+          # slsa-github-generator requires using a semver tag for reusable workflows. 
+          # See: https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators
+          allowlist: |
+            slsa-framework/slsa-github-generator

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,6 +28,8 @@ jobs:
           skip-cache: true
       - name: go fmt check
         run: make fmt-check
+      - name: go imports check
+        run: make imports-check
       - name: Checking unused pkgs using go mod tidy
         run: make unused-package-check
       - name: Go vet

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Lint
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup build env
+        uses: ./.github/actions/setup-build-env
+        timeout-minutes: 10
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        with:
+          version: v1.64
+          skip-cache: true
+      - name: go fmt check
+        run: make fmt-check
+      - name: Checking unused pkgs using go mod tidy
+        run: make unused-package-check
+      - name: Go vet
+        run: make vet

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,149 @@
+name: release-helm
+
+permissions: {}
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup build env
+        uses: ./.github/actions/setup-build-env
+        timeout-minutes: 30
+      - uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.12.1
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+
+  lint-artifacthub:
+    runs-on: ubuntu-latest
+    container:
+      image: artifacthub/ah
+      options: --user root
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run ah lint
+        working-directory: ./chart/
+        run: ah lint
+  
+  push-and-sign-install-manifest:
+    runs-on: ubuntu-latest
+    needs: create-release
+    permissions:
+      contents: write # needed to write releases
+      id-token: write # needed for keyless signing
+      packages: write # needed for ghcr access  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup build env
+        uses: ./.github/actions/setup-build-env
+        timeout-minutes: 10
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@6bf37f6a560fd84982d67f853162e4b3c2235edb # v2.6.4
+        with:
+          version: 0.35.0
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@fb28c2b6339dcd94da6e4cbcbc5e888961f6f8c3 # v3.9.0
+      - name: Build yaml manifest
+        run: VERSION=${{ github.ref_name }} make codegen-manifest-release
+      - name: Upload install manifest
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: .manifest/release.yaml
+          asset_name: install.yaml
+          tag: ${{ github.ref }}
+      - name: Upload CRD manifest
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: crd/**/*.yaml
+          file_glob: true
+          tag: ${{ github.ref }}
+      - name: Login to GHCR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push manifests to GHCR with Flux
+        env:
+          CR_PAT_ARTIFACTS:  ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          mkdir -p config/.release-manifests
+          cp .manifest/release.yaml config/.release-manifests/install.yaml
+          cd config/.release-manifests/ && \
+          flux push artifact oci://ghcr.io/${{ github.repository_owner }}/manifests/openreports:${{ github.ref_name }} \
+            --path="." \
+            --source="$(git config --get remote.origin.url)" \
+            --revision="${{ github.ref_name }}/$(git rev-parse HEAD)"
+      - name: Sign manifests in GHCR with Cosign
+        run: |
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/manifests/openreports:${{ github.ref_name }}
+
+  push-and-sign-helm-release:
+    runs-on: ubuntu-latest
+    needs: create-release
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      pages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup-build-env
+        uses: ./.github/actions/setup-build-env
+        timeout-minutes: 10
+      - name: Install helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.10.3
+        
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@fb28c2b6339dcd94da6e4cbcbc5e888961f6f8c3 # v3.9.0
+      
+      - name: Set version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      
+      - name: Set semver version
+        run: echo "RELEASE_SEMVER_VERSION=${RELEASE_VERSION#openreports-}" >> $GITHUB_ENV
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
+      - name: Create charts tmp directory
+        run: |
+          mkdir -p charts-tmp
+          cp -r chart charts-tmp/openreports
+      
+      - name: Run chart-releaser
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 #v1.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          linting: off
+          charts_dir: charts-tmp
+          chart_version: ${{ env.RELEASE_SEMVER_VERSION }}
+      
+      - name: Login to GitHub container registry
+        run: |
+          helm registry login ghcr.io -u ${GITHUB_ACTOR} -p ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Publish OCI Chart
+        run: |
+          helm package charts-tmp/openreports --version ${{ env.RELEASE_SEMVER_VERSION }} --destination .dist/
+          helm push .dist/openreports-*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts |& tee .digest
+          cosign login --username ${GITHUB_ACTOR} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/charts/openreports@$(cat .digest | awk -F "[, ]" '/Digest/{print $NF}')
+

--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -1,0 +1,23 @@
+name: Verify Codegen
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-codegen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup build env
+        uses: ./.github/actions/setup-build-env
+        timeout-minutes: 10
+      - name: Verify Codegen
+        run: |
+          make verify-codegen

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ bin
 *.swp
 *.swo
 *~
+
+# Helm
+charts-tmp/
+.dist
+.tools
+.manifest

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ codegen-api-docs: $(PACKAGE_SHIM) $(GEN_CRD_API_REFERENCE_DOCS) $(GENREF) ## Gen
 
 .PHONY: codegen-manifest-release
 codegen-manifest-release: ## Create CRD release manifest
+codegen-manifest-release: $(HELM)
 codegen-manifest-release: manifests
 	@echo Generating manifests for release... >&2
 	@mkdir -p ./.manifest

--- a/Makefile
+++ b/Makefile
@@ -14,32 +14,63 @@ LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
+CODEGEN_VERSION := v0.30.0-rc.2
+CODEGEN = $(shell pwd)/bin/code-generator
+CODEGEN_ROOT = $(shell $(GO_CMD) env GOMODCACHE)/k8s.io/code-generator@$(CODEGEN_VERSION)
 CONTROLLER_TOOLS_VERSION           ?= v0.18.0
 CONTROLLER_GEN                     ?= $(LOCALBIN)/controller-gen
 GEN_CRD_API_REFERENCE_DOCS         ?= $(LOCALBIN)/crd-ref-docs
 GEN_CRD_API_REFERENCE_DOCS_VERSION ?= latest
-
-#########
-# TOOLS #
-#########
-TOOLS_DIR                          ?= $(PWD)/.tools
-HELM                               ?= $(TOOLS_DIR)/helm
+HELM                               ?= $(LOCALBIN)/helm
 HELM_VERSION                       ?= v3.17.3
-TOOLS	:= $(HELM)
+GOIMPORTS                          ?= $(LOCALBIN)/goimports
+GOIMPORTS_VERSION                  ?= latest
+TOOLS := $(HELM)
 SED     := $(shell if [ "$(GOOS)" = "darwin" ]; then echo "gsed"; else echo "sed"; fi)
 
 $(HELM):
 	@echo Install helm... >&2
-	@GOBIN=$(TOOLS_DIR) go install helm.sh/helm/v3/cmd/helm@$(HELM_VERSION)
+	@GOBIN=$(LOCALBIN) go install helm.sh/helm/v3/cmd/helm@$(HELM_VERSION)
+
+$(GOIMPORTS):
+	@echo Install goimports... >&2
+	@GOBIN=$(LOCALBIN) go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+
+$(GEN_CRD_API_REFERENCE_DOCS): $(LOCALBIN)
+	test -s $(LOCALBIN)/crd-ref-docs && $(LOCALBIN)/crd-ref-docs --version | grep -q $(GEN_CRD_API_REFERENCE_DOCS_VERSION) || \
+	GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@$(GEN_CRD_API_REFERENCE_DOCS_VERSION)
+
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
+	GOBIN=$(LOCALBIN) $(GO_CMD) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: install-tools
 install-tools: ## Install tools
-install-tools: $(TOOLS)
+install-tools: $(TOOLS) $(GEN_CRD_API_REFERENCE_DOCS) $(CONTROLLER_GEN) $(GOIMPORTS)
 
 .PHONY: clean-tools
 clean-tools: ## Remove installed tools
 	@echo Clean tools... >&2
-	@rm -rf $(TOOLS_DIR)
+	@rm -rf $(LOCALBIN)
+
+all: code-generator manifests generate generate-api-docs generate-client build fmt vet
+
+generate-all: code-generator manifests generate generate-api-docs generate-client
+
+.PHONY: manifests
+manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: $(CONTROLLER_GEN)
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./apis/openreports.io/v1alpha1" output:crd:artifacts:config=crd/openreports.io/v1alpha1
+
+.PHONY: generate
+generate: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: $(CONTROLLER_GEN) 
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./apis/..."
+
+.PHONY: generate-client
+generate-client:
+	./hack/update-codegen.sh
+
 
 # Run go build against code
 build:
@@ -49,8 +80,6 @@ build:
 fmt:
 	go fmt ./...
 
-# Linting checks
-
 .PHONY: fmt-check
 fmt-check:
 	@echo "Checking go fmt..." >&2
@@ -59,73 +88,42 @@ fmt-check:
 	@echo 'To correct this, locally run "make fmt" and commit the changes.' >&2
 	@git diff --quiet --exit-code .
 
-.PHONY: unused-package-check
-unused-package-check:
-	@tidy=$$(go mod tidy); \
-	if [ -n "$${tidy}" ]; then \
-		echo "go mod tidy checking failed!"; echo "$${tidy}"; echo; \
-	fi
-
-
 # Run go vet against code
 vet:
 	go vet ./...
 
-.PHONY: all
-all: # Generate all code and build the project
-all:
-	codegen-all build fmt vet
+.PHONY: imports
+imports: $(GOIMPORTS)
+	@echo Go imports... >&2
+	@$(GOIMPORTS) -w .
 
-###########
-# CODEGEN #
-###########
+.PHONY: imports-check
+imports-check: imports
+	@echo Checking go imports... >&2
+	@git --no-pager diff .
+	@echo 'If this test fails, it is because the git diff is non-empty after running "make imports-check".' >&2
+	@echo 'To correct this, locally run "make imports" and commit the changes.' >&2
+	@git diff --quiet --exit-code .
 
-codegen-all: ## Generate all generated code
-codegen-all: codegen-code codegen-manifests codegen-controller codegen-api-docs codegen-client
-
-.PHONY: codegen-manifests
-codegen-manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-codegen-manifests: codegen-controller
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./apis/openreports.io/v1alpha1" output:crd:artifacts:config=crd/openreports.io/v1alpha1
-
-
-.PHONY: codegen-controller
-codegen-controller: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-codegen-controller: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
-	GOBIN=$(LOCALBIN) $(GO_CMD) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
-
-.PHONY: codegen-client
-codegen-client:
-	./hack/update-codegen.sh
-
-.PHONY: codegen-controller
-codegen-controller: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
-	GOBIN=$(LOCALBIN) $(GO_CMD) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
-
-# Use same code-generator version as k8s.io/api
-CODEGEN_VERSION := v0.30.0-rc.2
-CODEGEN = $(shell pwd)/bin/code-generator
-CODEGEN_ROOT = $(shell $(GO_CMD) env GOMODCACHE)/k8s.io/code-generator@$(CODEGEN_VERSION)
-.PHONY: codegen-code
-codegen-code:
+.PHONY: code-generator
+code-generator:
 	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install k8s.io/code-generator/cmd/client-gen@$(CODEGEN_VERSION)
 	cp -f $(CODEGEN_ROOT)/generate-groups.sh $(PROJECT_DIR)/bin/
 	cp -f $(CODEGEN_ROOT)/generate-internal-groups.sh $(PROJECT_DIR)/bin/
 	cp -f $(CODEGEN_ROOT)/kube_codegen.sh $(PROJECT_DIR)/bin/
 
-
-.PHONY: codegen-api-docs
-codegen-api-docs: ## Generate API docs
-codegen-api-docs: $(GEN_CRD_API_REFERENCE_DOCS)
+# generate-api-docs will create api docs
+generate-api-docs: $(GEN_CRD_API_REFERENCE_DOCS)
 	$(GEN_CRD_API_REFERENCE_DOCS) --source-path=./apis/openreports.io/v1alpha1 --config=./docs/config.yaml --renderer=markdown --output-path=./docs/api-docs.md
 
-$(GEN_CRD_API_REFERENCE_DOCS): $(LOCALBIN)
-	$(call go-install-tool,$(GEN_CRD_API_REFERENCE_DOCS),github.com/elastic/crd-ref-docs,$(GEN_CRD_API_REFERENCE_DOCS_VERSION))
-
+.PHONY: codegen-api-docs
+codegen-api-docs: $(PACKAGE_SHIM) $(GEN_CRD_API_REFERENCE_DOCS) $(GENREF) ## Generate API docs
+	@echo Generate api docs... >&2
+	$(GEN_CRD_API_REFERENCE_DOCS) -v=4 \
+		-api-dir pkg/api \
+		-config docs/config.json \
+		-template-dir docs/template \
+		-out-file docs/index.html
 
 .PHONY: codegen-manifest-release
 codegen-manifest-release: ## Create CRD release manifest
@@ -135,54 +133,21 @@ codegen-manifest-release: manifests
 	@$(HELM) template openreports chart/ \
 	| $(SED) -e '/^#.*/d' > ./.manifest/release.yaml
 
-#################
-# RELEASE NOTES #
-#################
-
-.PHONY: release-notes
-release-notes: ## Generate release notes
-	@echo Generating release notes... >&2
-	@bash -c 'while IFS= read -r line ; do if [[ "$$line" == "## "* && "$$line" != "## $(VERSION)" ]]; then break ; fi; echo "$$line"; done < "CHANGELOG.md"' \
-	true
-
-#################
-# VERIFY CODGEN #
-#################
-
 .PHONY: verify-codegen
 verify-codegen: ## Verify all generated code are up to date
-verify-codegen: codegen-all
+verify-codegen: generate-all
 	@echo Checking git diff... >&2
 	@echo 'If this test fails, it is because the git diff is non-empty after running "make codegen-all".' >&2
 	@echo 'To correct this, locally run "make codegen-all" and commit the changes.' >&2
 	@git diff --exit-code .
 
-#########
-# UTILS #
-#########
-
 .PHONY: copy-crd-to-helm
 copy-crd-to-helm: manifests ## Generate CRD YAMLs and copy them to the Helm chart templates directory
 	cp crd/openreports.io/v1alpha1/*.yaml chart/templates/
 
-# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
-# $1 - target path with name of binary (ideally with version)
-# $2 - package url which can be installed
-# $3 - specific version of package
-define go-install-tool
-@[ -f $(1) ] || { \
-set -e; \
-package=$(2)@$(3) ;\
-echo "Downloading $${package}" ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
-mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
-}
-endef
-
-
-########
-# HELP #
-########
-.PHONY: help
-help: ## Shows the available commands
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}'
+.PHONY: unused-package-check
+unused-package-check:
+	@tidy=$$(go mod tidy); \
+	if [ -n "$${tidy}" ]; then \
+		echo "go mod tidy checking failed!"; echo "$${tidy}"; echo; \
+	fi

--- a/README.md
+++ b/README.md
@@ -14,19 +14,41 @@ Each `Report` contains a set of `results` and a `summary`. Each `result` contain
 
 * [API Reference](./docs/api-docs.md)
 
+## Installing 
+
+Typically the Report API is installed and managed by a [producer](#producers). However, if you want to install it independently, there are multiple ways to do so:
+
+### Manifest
+
+```sh
+kubectl apply -f https://github.com/openreports/reports-api/releases/download/<version>/install.yaml
+```
+
+### Helm
+
+```sh
+# Using OCI
+helm install oci://ghcr.io/openreports/charts/openreports:<version>
+
+# Using the github repository
+helm repo add openreports https://openreports.github.io/reports-api
+helm install openreports/openreports
+```
+
 ## Demonstration
 
-Typically the Report API is installed and managed by a [producer](#producers). However, to try out the API in a test cluster you can follow the steps below:
+To try out the Report API in your cluster, you can follow the steps bellow:
 
 1. Add Report API CRDs to your cluster:
 
 ```sh
-kubectl create -f crd/openreports.io/v1alpha1/
+kubectl apply -f https://github.com/openreports/reports-api/releases/download/v0.1.0/install.yaml
+
 ```
 2. Create a sample policy report resource:
 
 ```sh
-kubectl create -f samples/sample-cis-k8s.yaml
+kubectl create -f https://raw.githubusercontent.com/openreports/reports-api/refs/heads/main/samples/sample-cis-k8s.yaml
 ```
 3. View policy report resources:
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,23 @@
 apiVersion: v2
 name: openreports
 description: A Helm chart for installing openreports APIs.
-version: 0.1.0
-appVersion: "1.0.0"
+version: v0.0.0
+appVersion: latest
+annotations:
+  artifacthub.io/home: https://github.com/openreports/openreports
+  artifacthub.io/sources: https://github.com/openreports/openreports
+  artifacthub.io/operator: "false"
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/crds: |
+    - kind: ClusterReport
+      version: v1alpha1
+      name: clusterreports.openreports.io
+      displayName: Cluster Report
+      description: ClusterReport is the Schema for the ClusterReport API
+    - kind: Report
+      version: v1alpha1
+      name: reports.openreports.io
+      displayName: Report
+      description: Report is the Schema for the Report API
+    
+


### PR DESCRIPTION
## Description

This PR adds GH workflows + actions in order to release the CRDs as:
- Downloadable CRDs YAML files as assets in the release 
- Helm chart stored in `gh-pages`
- Helm chart stored as OCI artifact (and signed via Cosign) in `ghcr.io/openreports/charts`
- An signe install manifest file with all CRDs in `ghcr.io/openreports/manifests`

Releases are created whenever a new tag starting with `v*` is created (eg: `v1.0.0`)

It also adds some `pre-merge checks:
- Linting checks (`fmt`, `vet`, `goimports`, unused packages, ...)
- Codegen verifier

as well as some improvements to the `Makefile` (mostly added comments + re-ordering for clarity)

## Proof manifest

For some examples you can go check my fork, where I tested releasing new versions: https://github.com/lucchmielowski/reports-api

## Related Issues

- Closes https://github.com/openreports/reports-api/issues/13

 