### PR TITLE
chore: Add crd copy to helm chart + CI check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean-tools: ## Remove installed tools
 
 all: code-generator manifests generate generate-api-docs generate-client build fmt vet
 
-generate-all: code-generator manifests generate generate-api-docs generate-client
+generate-all: code-generator manifests generate generate-api-docs generate-client copy-crd-to-helm
 
 .PHONY: manifests
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
@@ -136,7 +136,7 @@ codegen-manifest-release: manifests
 
 .PHONY: verify-codegen
 verify-codegen: ## Verify all generated code are up to date
-verify-codegen: generate-all
+verify-codegen: generate-all copy-crd-to-helm
 	@echo Checking git diff... >&2
 	@echo 'If this test fails, it is because the git diff is non-empty after running "make codegen-all".' >&2
 	@echo 'To correct this, locally run "make codegen-all" and commit the changes.' >&2

--- a/chart/templates/openreports.io_clusterreports.yaml
+++ b/chart/templates/openreports.io_clusterreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterreports.openreports.io
 spec:
   group: openreports.io
@@ -169,24 +169,8 @@ spec:
                   description: Subjects is an optional reference to the checked Kubernetes
                     resources
                   items:
-                    description: |-
-                      ObjectReference contains enough information to let you inspect or modify the referred object.
-                      ---
-                      New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                       1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                       2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                          restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                          Those cannot be well described when embedded.
-                       3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                       4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                          during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                          and the version of the actual struct is irrelevant.
-                       5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                          will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                      Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                      For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -200,7 +184,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -303,7 +286,6 @@ spec:
                   the event) or if no container name is specified "spec.containers[2]" (container with
                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                   referencing a part of an object.
-                  TODO: this design is not final and this field is subject to change in the future.
                 type: string
               kind:
                 description: |-

--- a/chart/templates/openreports.io_reports.yaml
+++ b/chart/templates/openreports.io_reports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: reports.openreports.io
 spec:
   group: openreports.io
@@ -169,24 +169,8 @@ spec:
                   description: Subjects is an optional reference to the checked Kubernetes
                     resources
                   items:
-                    description: |-
-                      ObjectReference contains enough information to let you inspect or modify the referred object.
-                      ---
-                      New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                       1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                       2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                          restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                          Those cannot be well described when embedded.
-                       3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                       4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                          during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                          and the version of the actual struct is irrelevant.
-                       5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                          will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                      Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                      For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -200,7 +184,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -303,7 +286,6 @@ spec:
                   the event) or if no container name is specified "spec.containers[2]" (container with
                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                   referencing a part of an object.
-                  TODO: this design is not final and this field is subject to change in the future.
                 type: string
               kind:
                 description: |-


### PR DESCRIPTION
# Description

When generating files, we are not updating the helm chart, causing it to be outdated with the current API version. 
This PR adds:
- An automatic move of newly generated api manifests to the helm chart when `generate-all`
- Check that helm was correctly updated if the api was updated