### PR TITLE
ci: Replace version by SHA for free-disk action

### DIFF
--- a/.github/actions/setup-build-env/action.yaml
+++ b/.github/actions/setup-build-env/action.yaml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: jlumbroso/free-disk-space@v1.3.1         # pin to the latest v1.3.1 release
+    - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       if: ${{ inputs.free-disk-space == 'true' }}
       with:
         android: true


### PR DESCRIPTION
## Description

We missed the necessary SHA pin on one GH action. This fixes the issue/