### PR TITLE
docs: Add Dynatrace as a report consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following is a list of projects that produce or consume policy reports:
 * [Nirmata Control Hub](https://nirmata.com/nirmata-control-hub/)
 * [Open Cluster Management](https://open-cluster-management.io/)
 * [SUSE Rancher](https://github.com/rancher/rancher)
-* [Dynatrace (via an OpenTelemetry Collector](https://docs.dynatrace.com/docs/secure/threat-observability/security-events-ingest/ingest-kyverno-data)
+* [Dynatrace (via an OpenTelemetry Collector)](https://docs.dynatrace.com/docs/secure/threat-observability/security-events-ingest/ingest-kyverno-data)
 
 ## Building 
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The following is a list of projects that produce or consume policy reports:
 * [Nirmata Control Hub](https://nirmata.com/nirmata-control-hub/)
 * [Open Cluster Management](https://open-cluster-management.io/)
 * [SUSE Rancher](https://github.com/rancher/rancher)
+* [Dynatrace (via an OpenTelemetry Collector](https://docs.dynatrace.com/docs/secure/threat-observability/security-events-ingest/ingest-kyverno-data)
 
 ## Building 
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -32,12 +32,12 @@ _Appears in:_
 | `apiVersion` _string_ | `openreports.io/v1alpha1` | | |
 | `kind` _string_ | `ClusterReport` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `source` _string_ | Source is an identifier for the source e.g. a policy engine that manages this report.<br />Use this field if all the results are produced by a single policy engine.<br />If the results are produced by multiple sources e.g. different engines or scanners,<br />then use the Source field at the ReportResult level. |  |  |
-| `scope` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core)_ | Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node) |  |  |
-| `scopeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | ScopeSelector is an optional selector for multiple scopes (e.g. Pods).<br />Either one of, or none of, but not both of, Scope or ScopeSelector should be specified. |  |  |
-| `configuration` _[ReportConfiguration](#reportconfiguration)_ | Configuration is an optional field which can be used to specify<br />a contract between Report generators and consumers |  |  |
-| `summary` _[ReportSummary](#reportsummary)_ | ReportSummary provides a summary of results |  |  |
-| `results` _[ReportResult](#reportresult) array_ | ReportResult provides result details |  |  |
+| `source` _string_ | Source is an identifier for the source e.g. a policy engine that manages this report.<br />Use this field if all the results are produced by a single policy engine.<br />If the results are produced by multiple sources e.g. different engines or scanners,<br />then use the Source field at the ReportResult level. |  | Optional: \{\} <br /> |
+| `scope` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core)_ | Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node) |  | Optional: \{\} <br /> |
+| `scopeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | ScopeSelector is an optional selector for multiple scopes (e.g. Pods).<br />Either one of, or none of, but not both of, Scope or ScopeSelector should be specified. |  | Optional: \{\} <br /> |
+| `configuration` _[ReportConfiguration](#reportconfiguration)_ | Configuration is an optional field which can be used to specify<br />a contract between Report generators and consumers |  | Optional: \{\} <br /> |
+| `summary` _[ReportSummary](#reportsummary)_ | ReportSummary provides a summary of results |  | Optional: \{\} <br /> |
+| `results` _[ReportResult](#reportresult) array_ | ReportResult provides result details |  | Optional: \{\} <br /> |
 
 
 #### ClusterReportList
@@ -71,8 +71,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `maxResults` _integer_ | MaxResults is the maximum number of results contained in the report |  |  |
-| `statusFilter` _[StatusFilter](#statusfilter) array_ | StatusFilter indicates that the Report contains only those reports with statuses specified in this list |  | Enum: [pass fail warn error skip] <br /> |
+| `maxResults` _integer_ | MaxResults is the maximum number of results contained in the report |  | Optional: \{\} <br /> |
+| `statusFilter` _[StatusFilter](#statusfilter) array_ | StatusFilter indicates that the Report contains only those reports with statuses specified in this list |  | Enum: [pass fail warn error skip] <br />Optional: \{\} <br /> |
 
 
 #### Report
@@ -91,12 +91,12 @@ _Appears in:_
 | `apiVersion` _string_ | `openreports.io/v1alpha1` | | |
 | `kind` _string_ | `Report` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `source` _string_ | Source is an identifier for the source e.g. a policy engine that manages this report.<br />Use this field if all the results are produced by a single policy engine.<br />If the results are produced by multiple sources e.g. different engines or scanners,<br />then use the Source field at the ReportResult level. |  |  |
-| `scope` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core)_ | Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node) |  |  |
-| `scopeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | ScopeSelector is an optional selector for multiple scopes (e.g. Pods).<br />Either one of, or none of, but not both of, Scope or ScopeSelector should be specified. |  |  |
-| `configuration` _[ReportConfiguration](#reportconfiguration)_ | Configuration is an optional field which can be used to specify<br />a contract between Report generators and consumers |  |  |
-| `summary` _[ReportSummary](#reportsummary)_ | ReportSummary provides a summary of results |  |  |
-| `results` _[ReportResult](#reportresult) array_ | ReportResult provides result details |  |  |
+| `source` _string_ | Source is an identifier for the source e.g. a policy engine that manages this report.<br />Use this field if all the results are produced by a single policy engine.<br />If the results are produced by multiple sources e.g. different engines or scanners,<br />then use the Source field at the ReportResult level. |  | Optional: \{\} <br /> |
+| `scope` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core)_ | Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node) |  | Optional: \{\} <br /> |
+| `scopeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | ScopeSelector is an optional selector for multiple scopes (e.g. Pods).<br />Either one of, or none of, but not both of, Scope or ScopeSelector should be specified. |  | Optional: \{\} <br /> |
+| `configuration` _[ReportConfiguration](#reportconfiguration)_ | Configuration is an optional field which can be used to specify<br />a contract between Report generators and consumers |  | Optional: \{\} <br /> |
+| `summary` _[ReportSummary](#reportsummary)_ | ReportSummary provides a summary of results |  | Optional: \{\} <br /> |
+| `results` _[ReportResult](#reportresult) array_ | ReportResult provides result details |  | Optional: \{\} <br /> |
 
 
 #### ReportConfiguration
@@ -148,16 +148,16 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `source` _string_ | Source is an identifier for the policy engine that manages this report<br />If the Source is specified at this level, it will override the Source<br />field set at the Report level |  |  |
+| `source` _string_ | Source is an identifier for the policy engine that manages this report<br />If the Source is specified at this level, it will override the Source<br />field set at the Report level |  | Optional: \{\} <br /> |
 | `policy` _string_ | Policy is the name or identifier of the policy |  |  |
-| `rule` _string_ | Rule is the name or identifier of the rule within the policy |  |  |
-| `category` _string_ | Category indicates policy category |  |  |
-| `severity` _[ResultSeverity](#resultseverity)_ | Severity indicates policy check result criticality |  | Enum: [critical high low medium info] <br /> |
+| `rule` _string_ | Rule is the name or identifier of the rule within the policy |  | Optional: \{\} <br /> |
+| `category` _string_ | Category indicates policy category |  | Optional: \{\} <br /> |
+| `severity` _[ResultSeverity](#resultseverity)_ | Severity indicates policy check result criticality |  | Enum: [critical high low medium info] <br />Optional: \{\} <br /> |
 | `timestamp` _[Timestamp](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#timestamp-v1-meta)_ | Timestamp indicates the time the result was found |  |  |
 | `result` _[Result](#result)_ | Result indicates the outcome of the policy rule execution |  | Enum: [pass fail warn error skip] <br /> |
 | `scored` _boolean_ | Scored indicates if this result is scored |  |  |
-| `resources` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core) array_ | Subjects is an optional reference to the checked Kubernetes resources |  |  |
-| `resourceSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | ResourceSelector is an optional label selector for checked Kubernetes resources.<br />For example, a policy result may apply to all pods that match a label.<br />Either a Subject or a ResourceSelector can be specified. If neither are provided, the<br />result is assumed to be for the policy report scope. |  |  |
+| `resources` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core) array_ | Subjects is an optional reference to the checked Kubernetes resources |  | Optional: \{\} <br /> |
+| `resourceSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | ResourceSelector is an optional label selector for checked Kubernetes resources.<br />For example, a policy result may apply to all pods that match a label.<br />Either a Subject or a ResourceSelector can be specified. If neither are provided, the<br />result is assumed to be for the policy report scope. |  | Optional: \{\} <br /> |
 | `message` _string_ | Description is a short user friendly message for the policy rule |  |  |
 | `properties` _object (keys:string, values:string)_ | Properties provides additional information for the policy rule |  |  |
 
@@ -176,11 +176,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `pass` _integer_ | Pass provides the count of policies whose requirements were met |  |  |
-| `fail` _integer_ | Fail provides the count of policies whose requirements were not met |  |  |
-| `warn` _integer_ | Warn provides the count of non-scored policies whose requirements were not met |  |  |
-| `error` _integer_ | Error provides the count of policies that could not be evaluated |  |  |
-| `skip` _integer_ | Skip indicates the count of policies that were not selected for evaluation |  |  |
+| `pass` _integer_ | Pass provides the count of policies whose requirements were met |  | Optional: \{\} <br /> |
+| `fail` _integer_ | Fail provides the count of policies whose requirements were not met |  | Optional: \{\} <br /> |
+| `warn` _integer_ | Warn provides the count of non-scored policies whose requirements were not met |  | Optional: \{\} <br /> |
+| `error` _integer_ | Error provides the count of policies that could not be evaluated |  | Optional: \{\} <br /> |
+| `skip` _integer_ | Skip indicates the count of policies that were not selected for evaluation |  | Optional: \{\} <br /> |
 
 
 #### Result


### PR DESCRIPTION
This PR:

- Adds Dynatrace as an OpenReports consumer via an OTEL collector