### PR TITLE
docs(README): fix `helm install` command instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ kubectl apply -f https://raw.githubusercontent.com/openreports/reports-api/refs/
 Using OCI:
 
 ```sh
-helm install oci://ghcr.io/openreports/charts/openreports:<version>
+helm install openreports oci://ghcr.io/openreports/charts/openreports:<version>
 ```
 
 Using the repository:


### PR DESCRIPTION
As-is, the `helm install` instruction in the README fails with:

```
Error: INSTALLATION FAILED: must either provide a name or specify --generate-name
```

given it misses the `[NAME]` mandatory argument. This PR fixes that.
